### PR TITLE
Enable RSS Autodiscovery

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,7 @@
   <!--[if lt IE 9]>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
+  <link rel="alternate" type="application/atom+xml" title="Lumen" href="/feed.xml">
 </head>
 
 <body>


### PR DESCRIPTION
Added a `<link>` element to `<head>` to enable [RSS Autodiscovery](https://www.rssboard.org/rss-autodiscovery).